### PR TITLE
krew: Rename kubectl-az to kubectl-aks

### DIFF
--- a/.github/workflows/kubectl-aks.yml
+++ b/.github/workflows/kubectl-aks.yml
@@ -1,11 +1,11 @@
-name: Microsoft Azure CLI kubectl plugin CI
+name: Microsoft AKS CLI kubectl plugin CI
 env:
   GO_VERSION: 1.17 # TODO: Update
-  AZURE_PREFIX: kubectl-az-ci
+  AZURE_PREFIX: kubectl-aks-ci
 concurrency:
   # Only one workflow can run at a time unless
   # we create a new AKS cluster per github_ref (branch)
-  group: kubectl-az-ci
+  group: kubectl-aks-ci
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    name: Build kubectl-az
+    name: Build kubectl-aks
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,13 +45,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and generate tarball
         run: |
-          target=kubectl-az-${{ matrix.os }}-${{ matrix.arch }}
+          target=kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}
 
           make $target
 
-          binary_name=kubectl-az
+          binary_name=kubectl-aks
           if [ ${{ matrix.os }} = "windows" ]; then
-            binary_name=kubectl-az.exe
+            binary_name=kubectl-aks.exe
           fi
 
           # Prepare binary as artifact, it will be used by other jobs
@@ -59,11 +59,11 @@ jobs:
           tar --sort=name --owner=root:0 --group=root:0 \
             -czf ${target}.tar.gz \
             $binary_name LICENSE
-      - name: Add kubectl-az-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact
+      - name: Add kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: kubectl-az-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
-          path: kubectl-az-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          name: kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
+          path: kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
   unit-tests:
     name: Run unit tests
@@ -170,15 +170,15 @@ jobs:
               exit 1
               ;;
           esac
-      - name: Get kubectl-az from artifact
+      - name: Get kubectl-aks from artifact
         uses: actions/download-artifact@v3
         with:
-          name: kubectl-az-${{ env.os }}-${{ matrix.arch }}-tar-gz
-      - name: Prepare kubectl-az binary
+          name: kubectl-aks-${{ env.os }}-${{ matrix.arch }}-tar-gz
+      - name: Prepare kubectl-aks binary
         shell: bash
         run: |
-          tar zxvf kubectl-az-${{ env.os }}-${{ matrix.arch }}.tar.gz
-          chmod +x kubectl-az
+          tar zxvf kubectl-aks-${{ env.os }}-${{ matrix.arch }}.tar.gz
+          chmod +x kubectl-aks
           ls -la
       - name: Login to Azure
         uses: azure/login@v1
@@ -196,7 +196,7 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: |
-          make integration-test -o kubectl-az
+          make integration-test -o kubectl-aks
 
   release:
     name: Release
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get all artifacts.
       uses: actions/download-artifact@v3
-    - name: Rename all artifacts to kubectl-az-${{ github.ref_name }}.tar.gz
+    - name: Rename all artifacts to kubectl-aks-${{ github.ref_name }}.tar.gz
       shell: bash
       run: |
-        for i in kubectl-az-*-*-tar-gz/kubectl-az-*-*.tar.gz; do
+        for i in kubectl-aks-*-*-tar-gz/kubectl-aks-*-*.tar.gz; do
           mv $i $(dirname $i)/$(basename $i .tar.gz)-${{ github.ref_name }}.tar.gz
         done
     - name: Create Release
@@ -222,12 +222,12 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Release ${{ github.ref }}
-    - name: Upload kubectl-az binaries to the release
+    - name: Upload kubectl-aks binaries to the release
       uses: csexton/release-asset-action@v2
       with:
-        pattern: "kubectl-az-*-*-tar-gz/kubectl-az-*-*.tar.gz"
+        pattern: "kubectl-aks-*-*-tar-gz/kubectl-aks-*-*.tar.gz"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}
     - name: Update new version in krew-index
-      if: github.repository == 'azure/kubectl-az'
+      if: github.repository == 'azure/kubectl-aks'
       uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 *.dll
 *.so
 *.dylib
-/kubectl-az
-/kubectl-az-*-*
+/kubectl-aks
+/kubectl-aks-*-*
 
 # Test binary, built with `go test -c`
 *.test

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,35 +1,37 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: az
+  name: aks
 spec:
   version: {{ .TagName }}
-  homepage: https://github.com/Azure/kubectl-az
+  homepage: https://github.com/Azure/kubectl-aks
   shortDescription: Interact with an AKS cluster
   description: |
     This plugin provides a set of commands that can be used to debug an AKS
     cluster even when the cluster's control plane is not working correctly. For
     instance, when the API server is having problems.
 
-    This plugin is not meant to replace az, but to complement it by providing
+    This plugin is not meant to replace az [1], but to complement it by providing
     additional commands and, mainly, allowing users to have a kubectl-like
     experience when working with an AKS cluster.
+
+    [1] https://learn.microsoft.com/en-us/cli/azure/
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/Azure/kubectl-az/releases/download/{{ .TagName }}/kubectl-az-linux-amd64-{{ .TagName }}.tar.gz" .TagName }}
-    bin: kubectl-az
+    {{addURIAndSha "https://github.com/Azure/kubectl-aks/releases/download/{{ .TagName }}/kubectl-aks-linux-amd64-{{ .TagName }}.tar.gz" .TagName }}
+    bin: kubectl-aks
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/Azure/kubectl-az/releases/download/{{ .TagName }}/kubectl-az-darwin-amd64-{{ .TagName }}.tar.gz" .TagName }}
-    bin: kubectl-az
+    {{addURIAndSha "https://github.com/Azure/kubectl-aks/releases/download/{{ .TagName }}/kubectl-aks-darwin-amd64-{{ .TagName }}.tar.gz" .TagName }}
+    bin: kubectl-aks
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/Azure/kubectl-az/releases/download/{{ .TagName }}/kubectl-az-windows-amd64-{{ .TagName }}.tar.gz" .TagName }}
-    bin: kubectl-az
+    {{addURIAndSha "https://github.com/Azure/kubectl-aks/releases/download/{{ .TagName }}/kubectl-aks-windows-amd64-{{ .TagName }}.tar.gz" .TagName }}
+    bin: kubectl-aks.exe

--- a/Makefile
+++ b/Makefile
@@ -12,28 +12,28 @@ else
 	VERSION := $(TAG)-dirty
 endif
 
-LDFLAGS := "-X github.com/Azure/kubectl-az/cmd.version=$(VERSION) -extldflags '-static'"
+LDFLAGS := "-X github.com/Azure/kubectl-aks/cmd.version=$(VERSION) -extldflags '-static'"
 
-.DEFAULT_GOAL := kubectl-az
+.DEFAULT_GOAL := kubectl-aks
 
 # Build
-KUBECTL_AZ_TARGETS = \
-	kubectl-az-linux-amd64 \
-	kubectl-az-linux-arm64 \
-	kubectl-az-darwin-amd64 \
-	kubectl-az-darwin-arm64 \
-	kubectl-az-windows-amd64
+KUBECTL_AKS_TARGETS = \
+	kubectl-aks-linux-amd64 \
+	kubectl-aks-linux-arm64 \
+	kubectl-aks-darwin-amd64 \
+	kubectl-aks-darwin-arm64 \
+	kubectl-aks-windows-amd64
 
-.PHONY: list-kubectl-az-targets
-list-kubectl-az-targets:
-	@echo $(KUBECTL_AZ_TARGETS)
+.PHONY: list-kubectl-aks-targets
+list-kubectl-aks-targets:
+	@echo $(KUBECTL_AKS_TARGETS)
 
-.PHONY: kubectl-az-all
-kubectl-az-all: $(KUBECTL_AZ_TARGETS)
+.PHONY: kubectl-aks-all
+kubectl-aks-all: $(KUBECTL_AKS_TARGETS)
 
-.PHONY: kubectl-az
-kubectl-az: kubectl-az-$(GOHOSTOS)-$(GOHOSTARCH)
-	mv kubectl-az-$(GOHOSTOS)-$(GOHOSTARCH) kubectl-az
+.PHONY: kubectl-aks
+kubectl-aks: kubectl-aks-$(GOHOSTOS)-$(GOHOSTARCH)
+	mv kubectl-aks-$(GOHOSTOS)-$(GOHOSTARCH) kubectl-aks
 
 # make does not allow implicit rules (with '%') to be phony so let's use
 # the 'phony_explicit' dependency to make implicit rules inherit the phony
@@ -41,19 +41,19 @@ kubectl-az: kubectl-az-$(GOHOSTOS)-$(GOHOSTARCH)
 .PHONY: phony_explicit
 phony_explicit:
 
-.PHONY: kubectl-az-%
-kubectl-az-%: phony_explicit
+.PHONY: kubectl-aks-%
+kubectl-aks-%: phony_explicit
 	export GO111MODULE=on CGO_ENABLED=0 && \
 	export GOOS=$(shell echo $* |cut -f1 -d-) GOARCH=$(shell echo $* |cut -f2 -d-) && \
 	go build -ldflags $(LDFLAGS) \
-		-o kubectl-az-$${GOOS}-$${GOARCH} \
-		github.com/Azure/kubectl-az
+		-o kubectl-aks-$${GOOS}-$${GOARCH} \
+		github.com/Azure/kubectl-aks
 
 # Install
 .PHONY: install
-install: kubectl-az
+install: kubectl-aks
 	mkdir -p ~/.local/bin/
-	cp kubectl-az ~/.local/bin/
+	cp kubectl-aks ~/.local/bin/
 
 # Run unit tests
 .PHONY: unit-test
@@ -62,15 +62,15 @@ unit-test:
 
 # Run integration tests
 .PHONY: integration-test
-integration-test: kubectl-az
-	KUBECTL_AZ="$(shell pwd)/kubectl-az" \
+integration-test: kubectl-aks
+	KUBECTL_AKS="$(shell pwd)/kubectl-aks" \
 		go test -v ./test/integration/... -integration
 
 # Clean
 .PHONY: clean
 clean:
-	rm -f kubectl-az
+	rm -f kubectl-aks
 
 .PHONY: cleanall
 cleanall: clean
-	rm -f $(KUBECTL_AZ_TARGETS)
+	rm -f $(KUBECTL_AKS_TARGETS)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Microsoft Azure CLI kubectl plugin
+# Microsoft Azure Kubernetes Service (AKS) CLI kubectl plugin
 
-`kubectl-az` is a `kubectl` plugin that provides a set of commands that can be
+`kubectl-aks` is a `kubectl` plugin that provides a set of commands that can be
 used to debug an AKS cluster even when the cluster's control plane is not
 working correctly. For instance, when the API server is having problems.
 
@@ -16,7 +16,7 @@ available command and which one is the most suitable for your case:
 - [check-apiserver-connectivity](docs/check-apiserver-connectivity.md)
 - [config](docs/config.md)
 
-Consider `kubectl-az` expects the cluster to use virtual machine scale sets,
+Consider `kubectl-aks` expects the cluster to use virtual machine scale sets,
 which is the case of an AKS cluster. And, the use of the `--node` flag requires
 the Kubernetes control plane to up and running, because the VMSS instance
 information of the node will be retrieved from the Kubernetes API server.
@@ -30,41 +30,41 @@ to the commands using the `--id` flag or separately with the `--subscription`,
 
 ## Install
 
-There is multiple ways to install the `kubectl-az`.
+There is multiple ways to install the `kubectl-aks`.
 
 ### Install a specific release
 
 It is possible to download the asset for a given release and platform from the
-[releases page](https://github.com/azure/kubectl-az/releases/), uncompress and
-move the `kubectl-az` executable to any folder in your `$PATH`.
+[releases page](https://github.com/azure/kubectl-aks/releases/), uncompress and
+move the `kubectl-aks` executable to any folder in your `$PATH`.
 
 ```bash
 VERSION=v0.1.0
-curl -sL https://github.com/azure/kubectl-az/releases/latest/download/kubectl-az-linux-amd64-${VERSION}.tar.gz | sudo tar -C /usr/local/bin -xzf - kubectl-az
-kubectl az version
+curl -sL https://github.com/azure/kubectl-aks/releases/latest/download/kubectl-aks-linux-amd64-${VERSION}.tar.gz | sudo tar -C /usr/local/bin -xzf - kubectl-aks
+kubectl aks version
 ```
 
 ### Compile from source
 
-To build `kubectl-az` from source, you'll need to have a Golang version 1.17
+To build `kubectl-aks` from source, you'll need to have a Golang version 1.17
 or higher installed:
 
 ```bash
-git clone https://github.com/Azure/kubectl-az.git
-cd kubectl-az
+git clone https://github.com/Azure/kubectl-aks.git
+cd kubectl-aks
 # Build and copy the resulting binary in $HOME/.local/bin/
 make install
-kubectl az version
+kubectl aks version
 ```
 
 ## Usage
 
 ```bash
-$ kubectl az --help
-Microsoft Azure CLI kubectl plugin
+$ kubectl aks --help
+Microsoft AKS CLI kubectl plugin
 
 Usage:
-  kubectl-az [command]
+  kubectl-aks [command]
 
 Available Commands:
   check-apiserver-connectivity Check connectivity between the nodes and the Kubernetes API Server
@@ -75,18 +75,18 @@ Available Commands:
   version                      Show version
 
 Flags:
-  -h, --help   help for kubectl-az
+  -h, --help   help for kubectl-aks
 
-Use "kubectl-az [command] --help" for more information about a command.
+Use "kubectl-aks [command] --help" for more information about a command.
 ```
 
-It is necessary to sign in to Azure to run any `kubectl-az` command. To do so,
+It is necessary to sign in to Azure to run any `kubectl-aks` command. To do so,
 you can use any authentication method provided by the [Azure
 CLI](https://github.com/Azure/azure-cli/) using the `az login` command; see
 further details
 [here](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli).
 However, if you do not have the Azure CLI or have not signed in yet,
-`kubectl-az` will open the default browser and load the Azure sign-in page where
+`kubectl-aks` will open the default browser and load the Azure sign-in page where
 you need to authenticate.
 
 ## Contributing

--- a/cmd/check-apiserver-connectivity.go
+++ b/cmd/check-apiserver-connectivity.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/kubectl-az/cmd/utils"
+	"github.com/Azure/kubectl-aks/cmd/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/kubectl-az/cmd/utils"
-	"github.com/Azure/kubectl-az/cmd/utils/config"
+	"github.com/Azure/kubectl-aks/cmd/utils"
+	"github.com/Azure/kubectl-aks/cmd/utils/config"
 )
 
 var configCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/Azure/kubectl-az/cmd/utils"
+	"github.com/Azure/kubectl-aks/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -14,8 +14,8 @@ import (
 var commonFlags utils.CommonFlags
 
 var rootCmd = &cobra.Command{
-	Use:   "kubectl-az",
-	Short: "Microsoft Azure CLI kubectl plugin",
+	Use:   "kubectl-aks",
+	Short: "Microsoft AKS CLI kubectl plugin",
 }
 
 func Execute() {

--- a/cmd/run-command.go
+++ b/cmd/run-command.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Azure/kubectl-az/cmd/utils"
+	"github.com/Azure/kubectl-aks/cmd/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/utils/auth.go
+++ b/cmd/utils/auth.go
@@ -20,7 +20,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 
-	"github.com/Azure/kubectl-az/cmd/utils/config"
+	"github.com/Azure/kubectl-aks/cmd/utils/config"
 )
 
 // https://github.com/Azure/azure-sdk-for-go/blob/sdk/azidentity/v0.13.0/sdk/azidentity/azidentity.go#L25
@@ -77,7 +77,7 @@ func newCachedInteractiveBrowserCredential() (*cachedInteractiveBrowserCredentia
 
 // GetToken implements the azcore.TokenCredential interface on cachedInteractiveBrowserCredential.
 func (c *cachedInteractiveBrowserCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (*azcore.AccessToken, error) {
-	// TODO: may be this can be improved with https://github.com/Azure/kubectl-az/issues/11
+	// TODO: may be this can be improved with https://github.com/Azure/kubectl-aks/issues/11
 	var account public.Account
 	if len(c.client.Accounts()) > 0 {
 		account = c.client.Accounts()[len(c.client.Accounts())-1]

--- a/cmd/utils/config/config.go
+++ b/cmd/utils/config/config.go
@@ -38,7 +38,7 @@ func Dir() string {
 		fmt.Fprintf(os.Stderr, "Warn: getting home directory: %s\n", err)
 		fmt.Fprintf(os.Stderr, "Warn: using current directory for config\n")
 	}
-	return path.Join(dir, ".kubectl-az")
+	return path.Join(dir, ".kubectl-aks")
 }
 
 // ShowConfig prints the configuration to stdout

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/kubectl-az/cmd/utils/config"
+	"github.com/Azure/kubectl-aks/cmd/utils/config"
 )
 
 const (
@@ -108,7 +108,7 @@ func addNodeFlags(command *cobra.Command, useFlagsOnly bool) {
 			}
 			// bind environment variables
 			config.AutomaticEnv()
-			config.SetEnvPrefix("kubectl_az")
+			config.SetEnvPrefix("kubectl_aks")
 			config.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 			// bind CLI flags

--- a/docs/check-apiserver-connectivity.md
+++ b/docs/check-apiserver-connectivity.md
@@ -10,7 +10,7 @@ aks-agentpool-27170680-vmss000000   Ready    agent   11d   v1.22.4
 aks-agentpool-27170680-vmss000001   Ready    agent   11d   v1.22.4
 aks-agentpool-27170680-vmss000002   Ready    agent   11d   v1.22.4
 
-$ kubectl az check-apiserver-connectivity --node aks-agentpool-27170680-vmss000000
+$ kubectl aks check-apiserver-connectivity --node aks-agentpool-27170680-vmss000000
 Running...
 
 Connectivity check: succeeded
@@ -19,11 +19,11 @@ Connectivity check: succeeded
 Or we could also pass directly the VMSS instance information:
 
 ```bash
-$ kubectl az check-apiserver-connectivity --id "/subscriptions/$SUBSCRIPTION/resourceGroups/$NODERESOURCEGROUP/providers/Microsoft.Compute/virtualMachineScaleSets/$VMSS/virtualmachines/$INSTANCEID"
+$ kubectl aks check-apiserver-connectivity --id "/subscriptions/$SUBSCRIPTION/resourceGroups/$NODERESOURCEGROUP/providers/Microsoft.Compute/virtualMachineScaleSets/$VMSS/virtualmachines/$INSTANCEID"
 ```
 
 ```bash
-$ kubectl az check-apiserver-connectivity --subscription $SUBSCRIPTION --node-resource-group $NODERESOURCEGROUP --vmss $VMSS --instance-id $INSTANCEID
+$ kubectl aks check-apiserver-connectivity --subscription $SUBSCRIPTION --node-resource-group $NODERESOURCEGROUP --vmss $VMSS --instance-id $INSTANCEID
 ```
 
 The `check-apiserver-connectivity` command verifies the connectivity between the
@@ -38,7 +38,7 @@ We can use the flag `-v`/`--verbose` to have further details about the command
 that is being executed in the nodes to check connectivity:
 
 ```bash
-$ kubectl az check-apiserver-connectivity --node aks-agentpool-27170680-vmss000001 -v
+$ kubectl aks check-apiserver-connectivity --node aks-agentpool-27170680-vmss000001 -v
 Command: kubectl --kubeconfig /var/lib/kubelet/kubeconfig version > /dev/null; echo $?
 Virtual Machine Scale Set VM:
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,16 +1,16 @@
 # Config
 
-We can use the `config` command to configure node information for `kubectl-az` commands.
+We can use the `config` command to configure node information for `kubectl-aks` commands.
 This allows ease of switching between different nodes and persisting the configuration. Nodes can be configured
 either specifying the `--node` or `--resource-id` or VMSS instance information(`--subscription`, `--node-resource-group`, `--vmss`, `--instance-id`).
 All three options are mutually exclusive:
 
 ```bash
-$ kubectl az config --help
+$ kubectl aks config --help
 Manage configuration
 
 Usage:
-  kubectl-az config [command]
+  kubectl-aks config [command]
 
 Available Commands:
   set-node           Set a given node in the configuration
@@ -24,15 +24,15 @@ Flags:
   -h, --help      help for config
   -v, --verbose   Verbose output.
 
-Use "kubectl-az config [command] --help" for more information about a command.
+Use "kubectl-aks config [command] --help" for more information about a command.
 ```
 
 As an example, we set a couple of nodes in the configuration (using VMSS instance information) and then switch between them:
 
 ```bash
-$ kubectl az config set-node node1 --subscription mySubID --node-resource-group myRG --vmss myVMSS --instance-id myInstanceID1
-$ kubectl az config set-node node2 --subscription mySubID --node-resource-group myRG --vmss myVMSS --instance-id myInstanceID2
-$ kubectl az show
+$ kubectl aks config set-node node1 --subscription mySubID --node-resource-group myRG --vmss myVMSS --instance-id myInstanceID1
+$ kubectl aks config set-node node2 --subscription mySubID --node-resource-group myRG --vmss myVMSS --instance-id myInstanceID2
+$ kubectl aks show
 nodes:
     node1:
         instance-id: myInstanceID1
@@ -45,11 +45,11 @@ nodes:
         subscription: mySubID
         vmss: myVMSS
 
-$ kubectl az config use-node node1
-$ kubectl az check-apiserver-connectivity
+$ kubectl aks config use-node node1
+$ kubectl aks check-apiserver-connectivity
 
-$ kubectl az config use-node node2
-$ kubectl az check-apiserver-connectivity
+$ kubectl aks config use-node node2
+$ kubectl aks check-apiserver-connectivity
 ```
 
 There is also an option to unset node information from the configuration using
@@ -68,9 +68,9 @@ NAME                                STATUS   ROLES   AGE   VERSION
 aks-agentpool-12345678-vmss000000   Ready    agent   4m    v1.23.15
 aks-agentpool-12345678-vmss000001   Ready    agent   4m    v1.23.15
 aks-agentpool-12345678-vmss000002   Ready    agent   4m    v1.23.15
-# Import nodes into kubectl-az
-$ kubectl az config import
-$ kubectl az config show
+# Import nodes into kubectl-aks
+$ kubectl aks config import
+$ kubectl aks config show
 nodes:
     aks-agentpool-12345678-vmss000000:
         instance-id: "0"
@@ -84,7 +84,7 @@ nodes:
         instance-id: "2"
         [...]
 # Start using one of those nodes
-$ kubectl az use-node aks-agentpool-12345678-vmss000000
+$ kubectl aks use-node aks-agentpool-12345678-vmss000000
 ```
 
 The information is stored with node name as key and VMSS instance information as value to avoid talking to be able
@@ -102,15 +102,15 @@ pass the node information to the commands. The precedence of the configuration i
 Using the flags:
 
 ```bash
-$ kubectl az check-apiserver-connectivity --node aks-agentpool-77471288-vmss000013
+$ kubectl aks check-apiserver-connectivity --node aks-agentpool-77471288-vmss000013
 ```
 
 or using the environment variables:
 
-- `KUBECTL_AZ_NODE`
-- `KUBECTL_AZ_RESOURCE_ID`
-- `KUBECTL_AZ_SUBSCRIPTION`, `KUBECTL_AZ_NODE_RESOURCE_GROUP`, `KUBECTL_AZ_VMSS` and `KUBECTL_AZ_INSTANCE_ID`
+- `KUBECTL_AKS_NODE`
+- `KUBECTL_AKS_RESOURCE_ID`
+- `KUBECTL_AKS_SUBSCRIPTION`, `KUBECTL_AKS_NODE_RESOURCE_GROUP`, `KUBECTL_AKS_VMSS` and `KUBECTL_AKS_INSTANCE_ID`
 
 ```bash
-$ KUBECTL_AZ_NODE=aks-agentpool-77471288-vmss000013 kubectl az check-apiserver-connectivity
+$ KUBECTL_AKS_NODE=aks-agentpool-77471288-vmss000013 kubectl aks check-apiserver-connectivity
 ```

--- a/docs/run-command.md
+++ b/docs/run-command.md
@@ -9,7 +9,7 @@ aks-agentpool-27170680-vmss000000   Ready    agent   11d   v1.22.4
 aks-agentpool-27170680-vmss000001   Ready    agent   11d   v1.22.4
 aks-agentpool-27170680-vmss000002   Ready    agent   11d   v1.22.4
 
-$ kubectl az run-command "ip route" --node aks-agentpool-27170680-vmss000000
+$ kubectl aks run-command "ip route" --node aks-agentpool-27170680-vmss000000
 Running...
 
 [stdout]
@@ -30,7 +30,7 @@ default via 10.240.0.1 dev eth0 proto dhcp src 10.240.0.4 metric 100
 
 Another example when requested command prints information to the standard error:
 ```
-$ kubectl az run-command "cat non-existent-file" --node aks-agentpool-27170680-vmss000000
+$ kubectl aks run-command "cat non-existent-file" --node aks-agentpool-27170680-vmss000000
 Running...
 
 [stdout]
@@ -42,11 +42,11 @@ cat: non-existent-file: No such file or directory
 Or we could also pass directly the VMSS instance information:
 
 ```bash
-$ kubectl az run-command "ip route" --id "/subscriptions/$SUBSCRIPTION/resourceGroups/$NODERESOURCEGROUP/providers/Microsoft.Compute/virtualMachineScaleSets/$VMSS/virtualmachines/$INSTANCEID"
+$ kubectl aks run-command "ip route" --id "/subscriptions/$SUBSCRIPTION/resourceGroups/$NODERESOURCEGROUP/providers/Microsoft.Compute/virtualMachineScaleSets/$VMSS/virtualmachines/$INSTANCEID"
 ```
 
 ```bash
-$ kubectl az run-command "ip route" --subscription $SUBSCRIPTION --node-resource-group $NODERESOURCEGROUP --vmss $VMSS --instance-id $INSTANCEID
+$ kubectl aks run-command "ip route" --subscription $SUBSCRIPTION --node-resource-group $NODERESOURCEGROUP --vmss $VMSS --instance-id $INSTANCEID
 ```
 
 Take into account that all the

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/kubectl-az
+module github.com/Azure/kubectl-aks
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@
 
 package main
 
-import "github.com/Azure/kubectl-az/cmd"
+import "github.com/Azure/kubectl-aks/cmd"
 
 func main() {
 	cmd.Execute()

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -16,10 +16,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func runKubectlAZ(t *testing.T, args ...string) string {
+func runKubectlAKS(t *testing.T, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command(os.Getenv("KUBECTL_AZ"), append(nodeFlag(t), args...)...)
+	cmd := exec.Command(os.Getenv("KUBECTL_AKS"), append(nodeFlag(t), args...)...)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.Stdout = stdout

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -23,8 +23,8 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	if os.Getenv("KUBECTL_AZ") == "" {
-		fmt.Fprintf(os.Stderr, "KUBECTL_AZ environment variable must be set to the path of the kubectl-az binary\n")
+	if os.Getenv("KUBECTL_AKS") == "" {
+		fmt.Fprintf(os.Stderr, "KUBECTL_AKS environment variable must be set to the path of the kubectl-aks binary\n")
 		os.Exit(1)
 	}
 
@@ -33,19 +33,19 @@ func TestMain(m *testing.M) {
 }
 
 func TestCheckAPIServerConnectivity(t *testing.T) {
-	out := runKubectlAZ(t, "check-apiserver-connectivity")
+	out := runKubectlAKS(t, "check-apiserver-connectivity")
 	require.Contains(t, out, "Connectivity check: succeeded")
 }
 
 func TestRunCommand(t *testing.T) {
 	// test stdout
-	out := runKubectlAZ(t, "run-command", "echo test")
+	out := runKubectlAKS(t, "run-command", "echo test")
 	stdout, stderr := parseRunCommand(t, out)
 	require.Equal(t, stdout, "test", "parseRunCommand() = %v, want %v", stdout, "test")
 	require.Empty(t, stderr, "parseRunCommand() = %v, want %v", stderr, "")
 
 	// test stderr
-	out = runKubectlAZ(t, "run-command", "echo test >&2")
+	out = runKubectlAKS(t, "run-command", "echo test >&2")
 	stdout, stderr = parseRunCommand(t, out)
 	require.Empty(t, stdout, "parseRunCommand() = %v, want %v", stdout, "")
 	require.Equal(t, stderr, "test", "parseRunCommand() = %v, want %v", stderr, "test")


### PR DESCRIPTION
Fixes #30 

## Todo

Before Merge: 
- [x] Setup the kubectl-aks-ci-rg for CI
- [x] Green CI Run

After Merge: 
- [ ] Clean up kubectl-az-ci-rg
- [ ] Rename the Repository

## Testing Done

```bash
→ make integration-test 
export GO111MODULE=on CGO_ENABLED=0 && \
export GOOS=linux GOARCH=amd64 && \
go build -ldflags "-X github.com/Azure/kubectl-aks/cmd.version=`git describe --tags --always`-dirty -extldflags '-static'" \
        -o kubectl-aks-${GOOS}-${GOARCH} \
        github.com/Azure/kubectl-aks
mv kubectl-aks-linux-amd64 kubectl-aks
KUBECTL_AKS="/home/qasim/work/github.com/Azure/kubectl-az/kubectl-aks" \
        go test -v ./test/integration/... -integration
Running integration tests
=== RUN   TestCheckAPIServerConnectivity
    integration_test.go:36: Running command: /home/qasim/work/github.com/Azure/kubectl-az/kubectl-aks --node aks-agentpool-77471288-vmss00001x check-apiserver-connectivity
    integration_test.go:36: Command output: 
        Running...
        
        Connectivity check: succeeded
--- PASS: TestCheckAPIServerConnectivity (24.09s)
=== RUN   TestRunCommand
    integration_test.go:42: Running command: /home/qasim/work/github.com/Azure/kubectl-az/kubectl-aks --node aks-agentpool-77471288-vmss00001x run-command echo test
    integration_test.go:42: Command output: 
        Running...
        
        [stdout]
        test
        
        [stderr]
    integration_test.go:48: Running command: /home/qasim/work/github.com/Azure/kubectl-az/kubectl-aks --node aks-agentpool-77471288-vmss00001x run-command echo test >&2
    integration_test.go:48: Command output: 
        Running...
        
        [stdout]
        
        [stderr]
        test
--- PASS: TestRunCommand (47.52s)
PASS
ok      github.com/Azure/kubectl-aks/test/integration   71.615s

```