### PR TITLE
lint: Introduce golang linter in the CI

### DIFF
--- a/.github/workflows/kubectl-aks.yml
+++ b/.github/workflows/kubectl-aks.yml
@@ -65,6 +65,26 @@ jobs:
           name: kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
           path: kubectl-aks-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
+  lint:
+    name: Run linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3.5.0
+        with:
+          # This version number must be kept in sync with Makefile lint one.
+          version: v1.53.2
+          working-directory: /home/runner/work/kubectl-aks/kubectl-aks
+          # Workaround to display the output:
+          # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
+          args: "--out-${NO_FUTURE}format colored-line-number"
+
   unit-tests:
     name: Run unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/kubectl-aks.yml
+++ b/.github/workflows/kubectl-aks.yml
@@ -110,7 +110,7 @@ jobs:
 
   create-aks-cluster:
     name: Create AKS cluster
-    needs: [ build, unit-tests ]
+    needs: [ build, lint, unit-tests ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+output:
+  sort-results: true
+
+run:
+  timeout: 10m
+
+issues:
+  exclude-use-default: false
+  max-same-issues: 0
+  max-issues-per-linter: 0
+  exclude-rules:
+    # Ignore check: Packages must have a package comment
+    - text: "ST1000: at least one file in a package should have a package comment"
+      linters:
+        - stylecheck
+
+linters:
+  disable-all: true
+  enable:
+    - gofumpt
+    - stylecheck
+    - staticcheck
+    - errorlint
+
+linters-settings:
+  gofumpt:
+    lang-version: "1.17"
+  staticcheck:
+    go: "1.17"
+    checks: ["all"]
+  stylecheck:
+    go: "1.17"
+    checks: ["all"]
+  errorlint:
+    # https://github.com/polyfloyd/go-errorlint
+    # Check whether fmt.Errorf uses the %w verb for formatting errors.
+    errorf: true
+    # Check for plain type assertions and type switches (errors.As must be used).
+    asserts: true
+    # Check for plain error comparisons (errors.Is must be used)
+    comparison: true

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ else
 	VERSION := $(TAG)-dirty
 endif
 
+LINTER_VERSION ?= v1.53.2
+
 LDFLAGS := "-X github.com/Azure/kubectl-aks/cmd.version=$(VERSION) -extldflags '-static'"
 
 .DEFAULT_GOAL := kubectl-aks
@@ -48,6 +50,14 @@ kubectl-aks-%: phony_explicit
 	go build -ldflags $(LDFLAGS) \
 		-o kubectl-aks-$${GOOS}-$${GOARCH} \
 		github.com/Azure/kubectl-aks
+
+# Lint
+.PHONY: lint
+lint:
+	docker run --rm --env XDG_CACHE_HOME=/tmp/xdg_home_cache \
+		--env GOLANGCI_LINT_CACHE=/tmp/golangci_lint_cache \
+		--user $(shell id -u):$(shell id -g) -v $(shell pwd):/app -w /app \
+		golangci/golangci-lint:$(LINTER_VERSION) golangci-lint run
 
 # Install
 .PHONY: install

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -123,13 +123,13 @@ func setNodeCmdRun(cmd *cobra.Command, args []string) error {
 func importCmdRun(cmd *cobra.Command, args []string) error {
 	vms, err := utils.VirtualMachineScaleSetVMsViaKubeconfig()
 	if err != nil {
-		return fmt.Errorf("failed to get VMSS VMs: %v", err)
+		return fmt.Errorf("failed to get VMSS VMs: %w", err)
 	}
 
 	cfg := config.New()
 	for nn, vm := range vms {
 		if err = cfg.SetNodeConfigWithVMSSInfoFlag(nn, vm.SubscriptionID, vm.NodeResourceGroup, vm.VMScaleSet, vm.InstanceID); err != nil {
-			return fmt.Errorf("failed to set node config for %s: %v", nn, err)
+			return fmt.Errorf("failed to set node config for %s: %w", nn, err)
 		}
 	}
 	return nil

--- a/cmd/utils/auth.go
+++ b/cmd/utils/auth.go
@@ -29,6 +29,8 @@ const (
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 )
 
+// GetCredentials returns a credential chain that will try to authenticate
+// using the Azure CLI and then using the interactive browser.
 // Further details about authentication:
 // https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity
 func GetCredentials() (*azidentity.ChainedTokenCredential, error) {
@@ -60,7 +62,7 @@ type cachedInteractiveBrowserCredential struct {
 
 func newCachedInteractiveBrowserCredential() (*cachedInteractiveBrowserCredential, error) {
 	file := path.Join(config.Dir(), "token-cache.json")
-	if err := os.MkdirAll(path.Dir(file), 0700); err != nil {
+	if err := os.MkdirAll(path.Dir(file), 0o700); err != nil {
 		return nil, fmt.Errorf("creating cache directory: %w", err)
 	}
 
@@ -117,7 +119,7 @@ func (t *tokenCache) Export(cache cache.Marshaler, key string) {
 	if err = json.Indent(&indentedData, data, "", "  "); err == nil {
 		data = indentedData.Bytes()
 	}
-	err = os.WriteFile(t.file, data, 0600)
+	err = os.WriteFile(t.file, data, 0o600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warn: writing token cache: %s\n", err)
 	}

--- a/cmd/utils/config/node.go
+++ b/cmd/utils/config/node.go
@@ -78,8 +78,9 @@ func (c *config) SetNodeConfigWithVMSSInfoFlag(nodeName, subscriptionIDFlag, nod
 }
 
 func (c *config) setNodeConfig(nodeName, nodeFlag, resourceIDFlag, subscriptionIDFlag,
-	nodeResourceGroupFlag, vmssFlag, instanceIDFlag string) error {
-	if err := os.MkdirAll(Dir(), 0700); err != nil {
+	nodeResourceGroupFlag, vmssFlag, instanceIDFlag string,
+) error {
+	if err := os.MkdirAll(Dir(), 0o700); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 	if err := c.ReadInConfig(); err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/cmd/utils/config/node_test.go
+++ b/cmd/utils/config/node_test.go
@@ -131,7 +131,7 @@ func createAndReadTempConfig(t *testing.T) *config {
 	require.Nil(t, err, "os.ReadFile(cfgPath) err = %v, want nil", err)
 	require.NotNil(t, data, "os.ReadFile(cfgPath) data = %v, want not nil", data)
 
-	err = os.WriteFile(cfgPath, data, 0600)
+	err = os.WriteFile(cfgPath, data, 0o600)
 	require.Nil(t, err, "os.WriteFile(cfgPath) = %v, want nil", err)
 
 	err = cfg.ReadInConfig()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -47,6 +47,7 @@ func AddCommonFlags(command *cobra.Command, flags *CommonFlags) {
 	)
 }
 
+// AddNodeFlags adds node flags and binds them to config/environment variables
 // Every command that allows user to specify the node name has three options:
 // (1) Provide the kubernetes node name
 // (2) Provide the VMMS instance information (--subscription, --node-resource-group, --vmss and --instance-id)


### PR DESCRIPTION
This PR introduces golang linter in CI. It uses `golangci/golangci-lint-action` to run the linter in workflow. Also, there is a new make target `lint` to run the liner locally using docker. 

Fixes: #17 