### PR TITLE
cmd: Use spinner for run-command

### DIFF
--- a/cmd/check-apiserver-connectivity.go
+++ b/cmd/check-apiserver-connectivity.go
@@ -28,6 +28,7 @@ func init() {
 }
 
 func connCheckCmdRun(cmd *cobra.Command, args []string) error {
+	utils.DefaultSpinner.Start()
 	cred, err := utils.GetCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to authenticate: %w", err)
@@ -71,7 +72,8 @@ func connCheckCmdRun(cmd *cobra.Command, args []string) error {
 		os.Exit(ret)
 	}
 
-	fmt.Println("\nConnectivity check: succeeded")
+	utils.DefaultSpinner.Stop()
+	fmt.Println("Connectivity check: succeeded")
 
 	return nil
 }

--- a/cmd/run-command.go
+++ b/cmd/run-command.go
@@ -53,6 +53,7 @@ func init() {
 }
 
 func runCommandCmdRun(cmd *cobra.Command, args []string) error {
+	utils.DefaultSpinner.Start()
 	cred, err := utils.GetCredentials()
 	if err != nil {
 		return fmt.Errorf("authenticating: %w", err)
@@ -73,6 +74,7 @@ func runCommandCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("running command: %w", err)
 	}
 
-	fmt.Printf("\n%s", res)
+	utils.DefaultSpinner.Stop()
+	fmt.Printf("%s", res)
 	return nil
 }

--- a/cmd/utils/vmss.go
+++ b/cmd/utils/vmss.go
@@ -230,8 +230,6 @@ func RunCommand(
 		return "", fmt.Errorf("couldn't begin running command: %w", err)
 	}
 
-	fmt.Println("Running...")
-
 	res, err := poller.PollUntilDone(ctx, pollingFreq)
 	if err != nil {
 		return "", fmt.Errorf("error polling command response: %w", err)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -76,10 +76,10 @@ func parseRunCommand(t *testing.T, out string) (string, string) {
 }
 
 func TestConfigImport(t *testing.T) {
-	subcriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 	resourceGroup := os.Getenv("AZURE_RESOURCE_GROUP")
 	clusterName := os.Getenv("AZURE_CLUSTER_NAME")
-	if subcriptionID == "" || resourceGroup == "" || clusterName == "" {
+	if subscriptionID == "" || resourceGroup == "" || clusterName == "" {
 		t.Fatal("AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, and AZURE_CLUSTER_NAME environment variables must be set to run this test")
 	}
 
@@ -95,7 +95,7 @@ func TestConfigImport(t *testing.T) {
 	_, err = os.ReadFile(configPath)
 	require.NotNil(t, err, "reading config file: %v", err)
 
-	runCommand(t, os.Getenv("KUBECTL_AKS"), "config", "import", "-s", subcriptionID, "-g", resourceGroup, "-c", clusterName)
+	runCommand(t, os.Getenv("KUBECTL_AKS"), "config", "import", "-s", subscriptionID, "-g", resourceGroup, "-c", clusterName)
 	azureConfigFile, err := os.ReadFile(configPath)
 	require.Nil(t, err, "reading config file: %v", err)
 	require.NotEmpty(t, azureConfigFile, "config file is empty")


### PR DESCRIPTION
This PR make `run-command` use spinner rather then "Running..." string.