### PR TITLE
vmss: Use OSProfile.ComputerName for Kubernetes node name

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -87,6 +87,13 @@ nodes:
 $ kubectl aks use-node aks-agentpool-12345678-vmss000000
 ```
 
+Or in case Kubernetes API is not available, we can also import the node information using Azure API by specifying the cluster information:
+
+```bash
+$ kubectl aks config import --subscription mySubID --resource-group myRG --cluster-name myCluster
+$ kubectl aks config show
+```
+
 The information is stored with node name as key and VMSS instance information as value to avoid talking to be able
 to continue talking with the node, even if the API server is not working correctly.
 


### PR DESCRIPTION
`armcompute.VirtualMachineScaleSetVM` already has the hostname of the node in the [properties](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/release-1.27/pkg/provider/azure_vmss.go#L478) so it is better to use it compared to using custom formatting logic. Also, add missing documentation for `config import` for Azure API.