### PR TITLE
Added darwin arm64 krew

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -36,6 +36,12 @@ spec:
     bin: kubectl-aks
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/Azure/kubectl-aks/releases/download/{{ .TagName }}/kubectl-aks-darwin-arm64-{{ .TagName }}.tar.gz" .TagName }}
+    bin: kubectl-aks
+  - selector:
+      matchLabels:
         os: windows
         arch: amd64
     {{addURIAndSha "https://github.com/Azure/kubectl-aks/releases/download/{{ .TagName }}/kubectl-aks-windows-amd64-{{ .TagName }}.tar.gz" .TagName }}


### PR DESCRIPTION
Fixing issue installing the plugin with krew on M1 and M2 based Macs
```shell
> uname -ms
Darwin arm64
> kubectl krew install aks
Updated the local copy of plugin index.
Installing plugin: aks
W0926 15:18:56.304641   54611 install.go:164] failed to install plugin "aks": plugin "aks" does not offer installation for this platform
failed to install some plugins: [aks]: plugin "aks" does not offer installation for this platform
```