### PR TITLE
spinner: Ensure there are no logs/prints between Start and Stop

### DIFF
--- a/cmd/check-apiserver-connectivity.go
+++ b/cmd/check-apiserver-connectivity.go
@@ -15,6 +15,7 @@ import (
 var connCheckCmd = &cobra.Command{
 	Use:          "check-apiserver-connectivity",
 	Short:        "Check connectivity between the nodes and the Kubernetes API Server",
+	Args:         cobra.NoArgs,
 	RunE:         connCheckCmdRun,
 	SilenceUsage: true,
 }

--- a/cmd/check-apiserver-connectivity.go
+++ b/cmd/check-apiserver-connectivity.go
@@ -27,7 +27,6 @@ func init() {
 }
 
 func connCheckCmdRun(cmd *cobra.Command, args []string) error {
-	utils.DefaultSpinner.Start()
 	cred, err := utils.GetCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to authenticate: %w", err)
@@ -54,7 +53,7 @@ func connCheckCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("couldn't parse stdout of response message:\n%s", res.Stdout)
 	}
 	if ret != 0 {
-		fmt.Printf("\nConnectivity check: failed with returned value %d: %s\n",
+		fmt.Printf("Connectivity check: failed with returned value %d: %s\n",
 			ret, res.Stderr)
 
 		// Force the binary to return an exit code != 0 (forwarding command's
@@ -62,7 +61,6 @@ func connCheckCmdRun(cmd *cobra.Command, args []string) error {
 		os.Exit(ret)
 	}
 
-	utils.DefaultSpinner.Stop()
 	fmt.Println("Connectivity check: succeeded")
 
 	return nil

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,6 +21,7 @@ var configCmd = &cobra.Command{
 var showConfigCmd = &cobra.Command{
 	Use:          "show",
 	Short:        "Show the configuration",
+	Args:         cobra.NoArgs,
 	RunE:         showConfigCmdRun,
 	SilenceUsage: true,
 }
@@ -35,6 +36,7 @@ var useNodeCmd = &cobra.Command{
 var unsetCurrentNodeCmd = &cobra.Command{
 	Use:          "unset-current-node",
 	Short:        "Unset the current node in the configuration",
+	Args:         cobra.NoArgs,
 	RunE:         unsetCurrentNodeCmdRun,
 	SilenceUsage: true,
 }
@@ -49,6 +51,7 @@ var unsetNodeCmd = &cobra.Command{
 var unsetAllCmd = &cobra.Command{
 	Use:          "unset-all",
 	Short:        "Unset all nodes in the configuration",
+	Args:         cobra.NoArgs,
 	RunE:         unsetAllCmdRun,
 	SilenceUsage: true,
 }
@@ -147,6 +150,7 @@ func importCmdCommand() *cobra.Command {
 			"In case of Azure API, you need to provide '--%s', '--%s' and '--%s' flags.",
 			utils.SubscriptionIDKey, utils.ResourceGroupKey, utils.ClusterNameKey),
 		SilenceUsage: true,
+		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			utils.DefaultSpinner.Start()
 			defer utils.DefaultSpinner.Stop()

--- a/cmd/run-command.go
+++ b/cmd/run-command.go
@@ -54,7 +54,6 @@ func init() {
 }
 
 func runCommandCmdRun(cmd *cobra.Command, args []string) error {
-	utils.DefaultSpinner.Start()
 	cred, err := utils.GetCredentials()
 	if err != nil {
 		return fmt.Errorf("authenticating: %w", err)
@@ -75,7 +74,6 @@ func runCommandCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("running command: %w", err)
 	}
 
-	utils.DefaultSpinner.Stop()
 	fmt.Fprintf(os.Stderr, "%s", res.Stderr)
 	fmt.Fprintf(os.Stdout, "%s", res.Stdout)
 	return nil

--- a/cmd/utils/vmss.go
+++ b/cmd/utils/vmss.go
@@ -258,13 +258,18 @@ func RunCommand(
 		os.Exit(1)
 	}()
 
+	DefaultSpinner.Start()
+	DefaultSpinner.Suffix = " Running..."
+
 	poller, err := client.BeginRunCommand(ctx, vm.NodeResourceGroup,
 		vm.VMScaleSet, vm.InstanceID, runCommand, nil)
 	if err != nil {
+		DefaultSpinner.Stop()
 		return nil, fmt.Errorf("begin running command: %w", err)
 	}
 
 	res, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: pollingFreq})
+	DefaultSpinner.Stop()
 	if err != nil {
 		return nil, fmt.Errorf("polling command response: %w", err)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,6 +19,7 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(version)
 	},


### PR DESCRIPTION
I just learned that Stop cleaned up the spinner and any prefix/suffix message you add to it, so I think we can use it while still keeping the final output clean:

## Before this PR

#### Example 1:

```bash
$ ./kubectl-aks config import
/ Importing...WARN[0030] Could not get VMSS VMs via Kubernetes API
WARN[0030] Please provide '--subscription', '--resource-group' and '--cluster-name' flags to get VMSS VMs via Azure API
Error: getting VMSS VMs via Kuberntes API: listing nodes: Get "https://172.28.128.4:6443/api/v1/nodes": dial tcp 172.28.128.4:6443: i/o timeout
```

#### Example 2:

```bash
$ ./kubectl-aks check-apiserver-connectivity
/ Checking connectivity...Connectivity check: failed with returned value 1
```

## After this PR

#### Example 1:

```bash
$ ./kubectl-aks config import
WARN[0030] Could not get VMSS VMs via Kubernetes API
WARN[0030] Please provide '--subscription', '--resource-group' and '--cluster-name' flags to get VMSS VMs via Azure API
Error: getting VMSS VMs via Kuberntes API: listing nodes: Get "https://172.28.128.4:6443/api/v1/nodes": dial tcp 172.28.128.4:6443: i/o timeout
```

#### Example 2:

```bash
$ ./kubectl-aks check-apiserver-connectivity
Connectivity check: failed with returned value 1:
```